### PR TITLE
21233

### DIFF
--- a/src/com/wolox/tasks/Task.groovy
+++ b/src/com/wolox/tasks/Task.groovy
@@ -11,7 +11,6 @@ class Task {
 
     String os = "linux"
     String nodeLabel = "LX_EL8"
-    String nodeType = ""
     String dispatcher
 
     // object containing information on

--- a/src/com/wolox/tasks/Task.groovy
+++ b/src/com/wolox/tasks/Task.groovy
@@ -11,6 +11,8 @@ class Task {
 
     String os = "linux"
     String nodeLabel = "LX_EL8"
+    String nodeType = ""
+    String dispatcher
 
     // object containing information on
     // other Tasks this Task depends on

--- a/vars/buildSteps.groovy
+++ b/vars/buildSteps.groovy
@@ -16,10 +16,14 @@ def call(String taskName, ProjectConfiguration projectConfig) {
 
     if (task.dispatcher) {
       node("${task.dispatcher}") {
+        println "Env vars for creating NB job: $env.GITHUB_CREDENTIAL $env.DEFAULT_USER"
         nodeName = "${task.nodeLabel}_" + now.format("YYYYMMdd_HHmmss")
         if (!Create_Node_Step(platform: task.os,
                               NodeClass: "${task.nodeLabel}",
-                              NodeLabel: "${nodeName}")) {
+                              NodeLabel: "${nodeName}",
+                              JenkinsUser: "${env.DEFAULT_USER}",
+                              TokenID: "${env.GITHUB_CREDENTIAL}",
+                              CIBranch: "private/kathywar/generic_server_token" )) {
           currentBuild.result = 'FAILURE'
         }
       }

--- a/vars/buildSteps.groovy
+++ b/vars/buildSteps.groovy
@@ -16,13 +16,11 @@ def call(String taskName, ProjectConfiguration projectConfig) {
 
     if (task.dispatcher) {
       node("${task.dispatcher}") {
-        println "Env vars for creating NB job: $env.GITHUB_CREDENTIAL $env.DEFAULT_USER"
         nodeName = "${task.nodeLabel}_" + now.format("YYYYMMdd_HHmmss")
         if (!Create_Node_Step(platform: task.os,
                               NodeClass: "${task.nodeLabel}",
                               NodeLabel: "${nodeName}",
-                              JenkinsUser: "${env.DEFAULT_USER}",
-                              TokenID: "${env.GITHUB_CREDENTIAL}",
+                              TokenID: "${env.JENKINS_API_CREDENTIAL}",
                               CIBranch: "private/kathywar/generic_server_token" )) {
           currentBuild.result = 'FAILURE'
         }

--- a/vars/buildSteps.groovy
+++ b/vars/buildSteps.groovy
@@ -12,7 +12,20 @@ def call(String taskName, ProjectConfiguration projectConfig) {
     Task task = projectConfig.tasks.tasks[taskName]
     task.state = TaskStates.RUNNING
 
-    node("${task.nodeLabel}") {
+    def nodeName = "${task.nodeLabel}"
+
+    if (task.dispatcher) {
+      node("${task.dispatcher}") {
+        nodeName = "${task.nodeLabel}_" + now.format("YYYYMMdd_HHmmss")
+        if (!Create_Node_Step(platform: task.os,
+                              NodeClass: "${task.nodeLabel}",
+                              NodeLabel: "${nodeName}")) {
+          currentBuild.result = 'FAILURE'
+        }
+      }
+    }
+
+    node("${nodeName}") {
 
       try {
 

--- a/vars/woloxCi.groovy
+++ b/vars/woloxCi.groovy
@@ -1,19 +1,23 @@
 import com.wolox.parser.ConfigParser
 import com.wolox.*
 
-def call(String defBranch, Boolean useDefBranch=false, String credential="github-cred", String yamlName="jenkins/jenkins.yml") {
+def call(String defBranch, Boolean useDefBranch=false, String tf_cred="tf-cred",
+         String yamlName="jenkins/jenkins.yml", String github_cred="github-cred") {
 
     def buildNumber = Integer.parseInt(env.BUILD_ID)
     println "Build number= $buildNumber"
 
     env.BLDID = "joblock-" + env.BUILD_NUMBER.toString()
-    env.CREDENTIAL = credential
+    env.GITHUB_CREDENTIAL = github_cred
+    env.CREDENTIAL=tf_cred
     env.DEFAULT_BRANCH=defBranch
 
     // must clone once to retrieve yaml file
     node('LX&&SC') {
 
         stage('initialize job') {
+            env.DEFAULT_USER=sh(script:'whoami', returnStdout:true)
+            println "Default user: $env.DEFAULT_USER"
             deleteDir()
             def wscreate = scmworkspace([], 15, useDefBranch)
             wscreate()

--- a/vars/woloxCi.groovy
+++ b/vars/woloxCi.groovy
@@ -1,4 +1,3 @@
-
 import com.wolox.parser.ConfigParser
 import com.wolox.*
 
@@ -21,6 +20,7 @@ def call(String defBranch, Boolean useDefBranch=false, String credential="github
         }
 
         def yaml = readYaml file: "$env.REPO_PATH/$yamlName"
+        println "Yaml: " + yaml
 
         // load project's configuration
         ProjectConfiguration projectConfig = ConfigParser.parse(yaml, env)
@@ -28,11 +28,15 @@ def call(String defBranch, Boolean useDefBranch=false, String credential="github
         buildName projectConfig.projectName
         buildDescription projectConfig.description
 
+        println "Project config: " + projectConfig.tasks.tasks
+
         // define parallel task closures
         def pTasks = [:]
         projectConfig.tasks.tasks.each { k, v ->
           String fullName = k
+          println "Task name: " + fullName
           if ( ! v.dependencies ) {
+            println "Adding task: " + fullName
             pTasks[(fullName)] =  buildSteps(fullName, projectConfig)
           }
         }


### PR DESCRIPTION
This is a change to allow jobs to use dynamically created nodes instead of permanent nodes. Also, I've made some style and formatting changes.

To specify a dynamically created node, the user specifies the 'dispatcher' text in the job yaml file:

    os:
      - LX_EL78: linux
        dispatcher: "sceler17"

The change also requires a user to pass in an api token credential if they don't (or can't) use the default credential created on the Jenkins server.