### PR TITLE
use master branch of llvm_ci library

### DIFF
--- a/vars/buildSteps.groovy
+++ b/vars/buildSteps.groovy
@@ -21,7 +21,7 @@ def call(String taskName, ProjectConfiguration projectConfig) {
                               NodeClass: "${task.nodeLabel}",
                               NodeLabel: "${nodeName}",
                               TokenID: "${env.JENKINS_API_CREDENTIAL}",
-                              CIBranch: "private/kathywar/generic_server_token" )) {
+                              CIBranch: "master" )) {
           currentBuild.result = 'FAILURE'
         }
       }


### PR DESCRIPTION
It's no longer needed to use a private branch to create a Netbatch-based node. Since the llvm_ci library has been updated, this capability is now in the master branch.